### PR TITLE
LabelBinarizer output should not be flattened

### DIFF
--- a/keras_text/data.py
+++ b/keras_text/data.py
@@ -38,8 +38,12 @@ class Dataset(object):
         self.test_indices = test_indices
 
         self.is_multi_label = isinstance(labels[0], (set, list, tuple))
-        self.label_encoder = MultiLabelBinarizer() if self.is_multi_label else LabelBinarizer()
-        self.y = self.label_encoder.fit_transform(self.y).flatten()
+        if self.is_multi_label:
+            self.label_encoder = MultiLabelBinarizer()
+            self.y = self.label_encoder.fit_transform(self.y).flatten()
+        else:
+            self.label_encoder = LabelBinarizer()
+            self.y = self.label_encoder.fit_transform(self.y)
 
     def update_test_indices(self, test_size=0.1):
         """Updates `test_indices` property with indices of `test_size` proportion.


### PR DESCRIPTION
current:
input_y = [1, 2, 3, 1]
self.y result to: [1 0 0 0 0 1 0 0 0 0 1 0 1 0 0 0 ]

changed to:
self.y result to: [[1 0 0 0], [0 1 0 0], [0 0 1 0], [1 0 0 0] ]